### PR TITLE
added continously automatic icon color updates for tile card

### DIFF
--- a/custom-icon-color.js
+++ b/custom-icon-color.js
@@ -83,7 +83,7 @@ window.customUI = {
                     const shadowRoot = this.shadowRoot;
                     if (shadowRoot?.childNodes) {
                       for (const node of shadowRoot.childNodes) {
-                        if (nodeName === 'HA-CARD') {
+                        if (node.nodeName === 'HA-CARD') {
                           node.style?.setProperty('--tile-color', iconColor, "important");
                           break;
                         }

--- a/custom-icon-color.js
+++ b/custom-icon-color.js
@@ -83,7 +83,7 @@ window.customUI = {
                     const shadowRoot = this.shadowRoot;
                     if (shadowRoot?.childNodes) {
                       for (const node of shadowRoot.childNodes) {
-                        if (node.nodeName?.localeCompare('ha-card', 'en', { sensitivity: 'base' }) == 0) {
+                        if (nodeName === 'HA-CARD') {
                           node.style?.setProperty('--tile-color', iconColor, "important");
                           break;
                         }


### PR DESCRIPTION
Hi,

after creating issue [#8 "Icon color of tile card only updated on page refresh"](https://github.com/Mariusthvdb/custom-icon-color/issues/8) and catching up with the discussion [#3 "add icon-color to Tile card"](https://github.com/Mariusthvdb/custom-icon-color/discussions/3) I spend some more time on how automatic update could be done for tile card without the need for page refresh or card_mod.
I found a way which I would like to present with this pull request.

Setting and modifiying icon_color attribute for entities with templates and showing those entities with tile cards for me results in exactly the same behaviour as the default behaviour if tile card with entities that change icon color on their own, e.g. lights.

I'm happy to take any comments and hope you like my contribution 😄 